### PR TITLE
Fixed an issue with multiple initializations of socket and corrected …

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -688,6 +688,20 @@ private buildKdbTimestampString(date : Date) {
 
   connectWS() {
     return new Promise((connected) => {
+      if (this.ws) {
+        if (this.ws.readyState == 1) {
+          connected(true);
+          return;
+        }
+        if (this.ws.readyState > 1) {
+          connected(false);
+          return;
+        }
+        this.ws.addEventListener('onopen', function () { connected(true); });
+        this.ws.addEventListener('onclose', function () { connected(false); });
+        return;
+      }
+
       this.ws = new WebSocket(this.wsUrl);
       this.ws.binaryType = 'arraybuffer';
       this.ws.onmessage = (response) => {
@@ -848,7 +862,7 @@ private buildKdbTimestampString(date : Date) {
   connect(): Promise<Object> {
     return new Promise<Object>((resolve, reject) => {
       if ('WebSocket' in window) {
-        this.$q.when(this.setupWebSocket()).then(
+        this.$q.when().then(
           setTimeout(() => {
             resolve(
               this.checkConnectionState().then((result) => {
@@ -918,19 +932,6 @@ private buildKdbTimestampString(date : Date) {
         }
       });
     });
-  }
-
-  setupWebSocket() {
-    this.ws = new WebSocket(this.wsUrl);
-    this.ws.binaryType = 'arraybuffer';
-
-    this.ws.onopen = () => {};
-
-    this.ws.onmessage = (messageEvent: MessageEvent) => {};
-
-    this.ws.onclose = () => {};
-
-    this.ws.onerror = () => {};
   }
 
   buildResponse(status: string, message: string, title: string) {


### PR DESCRIPTION
…testing a connection on the configuration page
Closes #36

Looks like when there are multiple variables from kdb, then connectWS get called multiple times, rewriting socket and breaking promises
I've tried to reproduce his video https://vimeo.com/489410176 on last grafana version
Also noticed what in video on variable configuration page, in query options Refresh is setted to Never, that's not an option in latest grafana